### PR TITLE
added EmbedImage module.

### DIFF
--- a/app/ImageMod/EmbedImage.cxx
+++ b/app/ImageMod/EmbedImage.cxx
@@ -1,0 +1,127 @@
+#ifndef __EMBEDIMAGE_CXX__
+#define __EMBEDIMAGE_CXX__
+
+#include "EmbedImage.h"
+#include "DataFormat/EventImage2D.h"
+
+namespace larcv {
+
+  static EmbedImageProcessFactory __global_EmbedImageProcessFactory__;
+
+  EmbedImage::EmbedImage(const std::string name)
+    : ProcessBase(name)
+  {}
+    
+  void EmbedImage::configure(const PSet& cfg)
+  {
+    fInputProducer  = cfg.get<std::string>("InputProducerName");  // input producer
+    fOutputProducer = cfg.get<std::string>("OutputProducerName"); // input producer    
+    fOutputRows     = cfg.get<int>("OutputRows");
+    fOutputCols     = cfg.get<int>("OutputCols");
+    finplace = ( fInputProducer==fOutputProducer ) ? true : false;
+  }
+
+  void EmbedImage::initialize()
+  {}
+
+  bool EmbedImage::process(IOManager& mgr)
+  {
+
+    EventImage2D* event_original = (EventImage2D*)mgr.get_data(kProductImage2D, fInputProducer);
+    EventImage2D* event_resize   = NULL;
+    if (!finplace)
+      event_resize  = (EventImage2D*)mgr.get_data(kProductImage2D, fOutputProducer);
+    else
+      event_resize  = event_original;
+
+    if ( !event_original ) {
+      LARCV_ERROR() << "Could not open input images." << std::endl;
+      return false;
+    }
+    if ( !event_resize )  {
+      LARCV_ERROR() << "Could not open output image holder." << std::endl;
+      return false;      
+    }
+
+    std::vector< larcv::Image2D> image_v;
+    event_original->Move(image_v ); // original moves ownership of its image vectors to us
+ 
+    std::vector< larcv::Image2D > resize_image_v; // space for new images if we are not working in place
+
+
+    std::vector<float> _buffer;
+    for ( size_t i=0; i<image_v.size(); ++i ) {
+
+      // get access to the data
+      larcv::Image2D& original_image = image_v[i];
+      
+      // get the image size
+      int orig_rows = original_image.meta().rows();
+      int orig_cols = original_image.meta().cols();
+      
+      if ( orig_rows>fOutputRows ) {
+	LARCV_ERROR() << "Image is taller than Embedding image (" << orig_rows << ">" << fOutputRows << ")" << std::endl;
+	return false;
+      }
+      if ( orig_cols>fOutputCols ) {
+	LARCV_ERROR() << "Image is wider than Embedding image (" << orig_cols << ">" << fOutputCols <<")" << std::endl;
+	return false;
+      }
+
+      // get the origin
+      float topleft_x = original_image.meta().min_x();
+      float topleft_y = original_image.meta().max_y();
+
+      // get width
+      float width_per_pixel  = original_image.meta().pixel_width();
+      float height_per_pixel = original_image.meta().pixel_height();
+      
+      // get new width, keeping same pixel scales
+      float new_width  = float(fOutputCols)*width_per_pixel;
+      float new_height = float(fOutputRows)*height_per_pixel;
+
+      // new origin
+      int offset_row = 0.5*(fOutputRows-orig_rows);
+      int offset_col = 0.5*(fOutputCols-orig_cols);
+      float new_topleft_x = topleft_x - offset_row*width_per_pixel;
+      float new_topleft_y = topleft_y + offset_col*height_per_pixel;
+
+      std::cout << "pixel size: width/pixel=" << width_per_pixel << " height/pixel=" << height_per_pixel << std::endl;
+      std::cout << "origin x: " << topleft_x << " --> " << new_topleft_x << std::endl;
+      std::cout << "origin y: " << topleft_y << " --> " << new_topleft_y << std::endl;
+      
+      // define the new meta
+      larcv::ImageMeta new_meta( new_width, new_height,
+				 fOutputRows, fOutputCols,
+				 new_topleft_x, new_topleft_y, 
+				 original_image.meta().plane() );
+
+      // define the new image
+      larcv::Image2D new_image( new_meta );
+      new_image.paint( 0.0 );
+      new_image.overlay( original_image );
+      
+      resize_image_v.emplace_back( std::move(new_image) );
+    }
+
+    // store
+    if ( finplace ) {
+      // give the new images
+      event_original->Emplace( std::move(resize_image_v) );
+    }
+    else {
+      // return the original images
+      event_original->Emplace( std::move( image_v ) );
+      // we give the new image2d container our relabeled images
+      event_resize->Emplace( std::move(resize_image_v) );
+    }
+    
+    return true;
+    
+  }
+
+  void EmbedImage::finalize()
+  {}
+
+}
+#endif

--- a/app/ImageMod/EmbedImage.h
+++ b/app/ImageMod/EmbedImage.h
@@ -1,0 +1,75 @@
+/**
+ * \file EmbedImage.h
+ *
+ * \ingroup Package_Name
+ * 
+ * \brief Class def header for a class EmbedImage
+ *
+ * @author taritree
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __EMBEDIMAGE_H__
+#define __EMBEDIMAGE_H__
+
+#include "Processor/ProcessBase.h"
+#include "Processor/ProcessFactory.h"
+
+#include <string>
+
+namespace larcv {
+
+  /**
+     \class ProcessBase
+     User defined class EmbedImage ... these comments are used to generate
+     doxygen documentation!
+  */
+  class EmbedImage : public ProcessBase {
+
+  public:
+    
+    /// Default constructor
+    EmbedImage(const std::string name="EmbedImage");
+    
+    /// Default destructor
+    ~EmbedImage(){}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+  protected:
+
+    std::string fInputProducer;
+    std::string fOutputProducer;
+    int fOutputRows;
+    int fOutputCols;
+    bool finplace;
+
+  };
+
+  /**
+     \class larcv::EmbedImageFactory
+     \brief A concrete factory class for larcv::EmbedImage
+  */
+  class EmbedImageProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    EmbedImageProcessFactory() { ProcessFactory::get().add_factory("EmbedImage",this); }
+    /// dtor
+    ~EmbedImageProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new EmbedImage(instance_name); }
+  };
+
+}
+
+#endif
+/** @} */ // end of doxygen group 
+

--- a/app/ImageMod/LinkDef.h
+++ b/app/ImageMod/LinkDef.h
@@ -24,8 +24,10 @@
 #pragma link C++ class larcv::MeanSubtraction+;
 #pragma link C++ class larcv::SegmentRelabel+;
 #pragma link C++ class larcv::WireMask+;
+#pragma link C++ class larcv::EmbedImage+;
 //ADD_NEW_CLASS ... do not change this line
 #endif
+
 
 
 

--- a/app/ImageMod/README.md
+++ b/app/ImageMod/README.md
@@ -14,7 +14,49 @@ Short description of each module can be found in the table below, followed by de
 
 ## Description of each module
 
-Please provide a detailed description of each module here.
+Please provide a detailed description of each module here. (Sorted in Alphabetical order)
+
+List of modules:
+
+* EmbedImage
+* SegmentRelabel
+* WireMask
+
+### EmbedImage
+
+This module embeds an image of a certain size (row,col) into a larger (row',col') image. 
+It attempts to be consistent about the Meta information, expanding the state width and height, along with adjusting the (x,y) origins.
+The initial use case was to embed an HiRes cropped image into an image that is a nice power of 2.
+This makes architectures like FCN or U-Net easier to construct.
+
+N.B. This does somethig similar to ResizeImage. 
+However, the approach to specifying transformation is different enough to make a new module.
+ResizeImage requires one to respecify the meta for each image.  
+EmbedImage makes a modification to the number of rows and cols, inferring the other meta parameters from the original meta.
+For HiRes cropped images, this is useful because things like the origin will change from image to image.
+
+Parameters
+
+| Parameters | Description |
+|------------|:-----------:|
+| InputProducerName | name of input image2d |
+| OutputProducerName | name of output image2d. if same as InputSegmentProducerName, then modification in-place (i.e. original image modified). |
+| OutputRows | size of output rows (must be bigger than original) |
+| OutputCols | size of output cols (must be bigger than original) |
+
+
+### SegmentRelabel
+
+The intention of this module is to relabel the segmentation image.  
+For example, we might want to relabel electrons and gammas as "showers" or relabel muon and pions as "tracks".
+
+Parameters
+
+| Parameters | Description |
+|------------|:-----------:|
+| InputSegmentProducerName | name of input segment image2d |
+| OutputSegmentProducerName | name of output  segment image2d. if same as InputSegmentProducerName, then stored in-place |
+| LabelMap | PSet connecting new label to a list of old labels. ex. 0:[0,1,2]. You can find example in segmentrelabel.cfg |
 
 ### WireMask
 
@@ -36,18 +78,6 @@ Parameters
 | WireList | integer array of wire numbers to be masked|
 | MaskValue | floating point used as a value for masking |
 
-### SegmentRelabel
-
-The intention of this module is to relabel the segmentation image.  
-For example, we might want to relabel electrons and gammas as "showers" or relabel muon and pions as "tracks".
-
-Parameters
-
-| Parameters | Description |
-|------------|:-----------:|
-| InputSegmentProducerName | name of input segment image2d |
-| OutputSegmentProducerName | name of output  segment image2d. if same as InputSegmentProducerName, then stored in-place |
-| LabelMap | PSet connecting new label to a list of old labels. ex. 0:[0,1,2]. You can find example in segmentrelabel.cfg |
 
 
 

--- a/app/ImageMod/embedimage.cfg
+++ b/app/ImageMod/embedimage.cfg
@@ -1,0 +1,31 @@
+
+ProcessDriver: {
+
+  Verbosity:    0
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["EmbedImage"]
+  ProcessName:  ["EmbedImage"]
+
+  IOManager: {
+    Verbosity:   0
+    Name:        "IOManager"
+    IOMode:      2
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: [               0,                 0]
+    StoreOnlyName: ["tpc_hires_crop","tpc_hires_resize"]
+  }
+
+  ProcessList: {
+    EmbedImage: {
+      Verbosity: 0
+      InputProducerName: "tpc_hires_crop"
+      OutputProducerName:"tpc_hires_resize"
+      OutputRows: 512
+      OutputCols: 512
+    }
+  }
+}
+


### PR DESCRIPTION
Added an EmbedImage module. It does a very similar operation as to ResizeImage. However, ResizeImage asks the user to specify the new meta data for each image.  For situations where this might change event-to-event, e.g. HiRes cropped images, the new meta will change.  Instead, EmbedImage, changes the rows and cols (expanding them) and uses the original meta of the given image to infer the other new meta parameters.
