### PR TITLE
Added VertexImg Module: makes image marking vertex

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,7 +19,7 @@ endif
 
 APP_SUBDIRS := ImageAna ImageMod Filter PMTWeights HiResDivider Merger APICaffe
 ifdef LARLITE_BASEDIR
-APP_SUBDIRS += Supera/APILArLite
+APP_SUBDIRS += Supera/APILArLite VertexImg
 endif
 
 .phony: all clean

--- a/app/VertexImg/GNUmakefile
+++ b/app/VertexImg/GNUmakefile
@@ -1,0 +1,31 @@
+#
+# This is an example GNUmakefile for my packages
+#
+PACKAGE_NAME = VertexImg
+
+# specific names for this package
+SOURCES = $(wildcard *.cxx)
+FMWK_HEADERS = LinkDef.h
+HEADERS = $(filter-out $(FMWK_HEADERS), $(wildcard *.h))
+#HEADERS += IOManager.inl
+
+# include options for this package
+INCFLAGS  = -I.                       #Include itself
+INCFLAGS += $(shell larcv-config --includes)
+INCFLAGS += $(shell larlite-config --includes)
+
+# platform-specific options
+OSNAME          = $(shell uname -s)
+HOST            = $(shell uname -n)
+OSNAMEMODE      = $(OSNAME)
+
+include $(LARCV_BASEDIR)/Makefile/Makefile.${OSNAME}
+
+LDFLAGS += $(shell larcv-config --libs)
+LDFLAGS += $(shell larlite-config --libs)
+# call the common GNUmakefile
+include $(LARCV_BASEDIR)/Makefile/GNUmakefile.CORE
+
+pkg_build:
+
+pkg_clean:

--- a/app/VertexImg/LinkDef.h
+++ b/app/VertexImg/LinkDef.h
@@ -1,0 +1,31 @@
+//
+// cint script to generate libraries
+// Declaire namespace & classes you defined
+// #pragma statement: order matters! Google it ;)
+//
+
+#ifdef __CINT__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class larcv::VertexImg+;
+//ADD_NEW_CLASS ... do not change this line
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/VertexImg/README.md
+++ b/app/VertexImg/README.md
@@ -1,0 +1,18 @@
+# VertexImg
+
+This module uses ROI to make a vertex "image".  Here we mark pixels with 1 in the neighborhood of the interaction vertex.
+
+Note that this module uses MicroBooNE detector constants from LArLite.  So only built if LARLITE is setup.
+
+## Usage
+
+Parameters
+
+| Parameters | Description |
+|------------|:-----------:|
+| ROIProducerName    | Input ROI producer name |
+| ImageProducerName  | Input image producer name |
+| OutputProducerName | Output image producer name. If same as ImageProducerName, then edited in place. |
+| VertexRadius       | Radius within which pixels are marked as a vertex |
+| ImageTickStart     | tick number that whole event view image starts at (usually 2400) |
+| MarkValue          | value given to pixels around vertex (default: 1) |

--- a/app/VertexImg/VertexImg.cxx
+++ b/app/VertexImg/VertexImg.cxx
@@ -1,0 +1,181 @@
+#ifndef __VERTEXIMG_CXX__
+#define __VERTEXIMG_CXX__
+
+#include "VertexImg.h"
+
+#include "DataFormat/EventImage2D.h"
+#include "DataFormat/EventROI.h"
+
+// larlite
+#include "LArUtil/Geometry.h"
+#include "LArUtil/TimeService.h"
+#include "LArUtil/LArProperties.h"
+
+namespace larcv {
+
+  static VertexImgProcessFactory __global_VertexImgProcessFactory__;
+
+  VertexImg::VertexImg(const std::string name)
+    : ProcessBase(name)
+  {}
+    
+  void VertexImg::configure(const PSet& cfg)
+  {
+    fROIProducerName    = cfg.get<std::string>("ROIProducerName");
+    fImageProducerName  = cfg.get<std::string>("ImageProducerName");
+    fOutputProducerName = cfg.get<std::string>("OutputProducerName");
+    fImageTickStart     = cfg.get<int>("ImageTickStart");
+    fVertexRadius       = cfg.get<int>("VertexRadius");
+    fMarkValue          = cfg.get<int>("MarkValue",1);
+    if ( fImageProducerName==fOutputProducerName )
+      finplace = true;
+    else
+      finplace = false;
+  }
+
+  void VertexImg::initialize()
+  {}
+
+  bool VertexImg::process(IOManager& mgr)
+  {
+    
+
+    EventImage2D* event_original = (EventImage2D*)mgr.get_data(kProductImage2D, fImageProducerName);
+    EventImage2D* event_vertex   = NULL;
+    EventROI*     event_roi      = (EventROI*)mgr.get_data(kProductROI, fROIProducerName);
+    if (!finplace)
+      event_vertex  = (EventImage2D*)mgr.get_data(kProductImage2D, fOutputProducerName);
+    else
+      event_vertex  = event_original;
+
+    if ( !event_original ) {
+      LARCV_ERROR() << "Could not open input images." << std::endl;
+      return false;
+    }
+    if ( !event_vertex )  {
+      LARCV_ERROR() << "Could not open output image holder." << std::endl;
+      return false;      
+    }
+
+    // find neutrino interaction      
+    bool vertex_found = false;
+    TVector3 vertex;
+    double vertex_t = 0.0;
+    double vertex_tdrift = 0.0;
+    double vertex_tick = 0;
+    double vertex_tg4elec = 0;
+    LARCV_DEBUG() << "Drift velocity: " << ::larutil::LArProperties::GetME()->DriftVelocity() << " cm/us" << std::endl;
+    LARCV_DEBUG() << "Trigger Time: " << ::larutil::TimeService::GetME()->TriggerTime() << " us" << std::endl;
+    LARCV_DEBUG() << "Trigger offset: " << ::larutil::TimeService::GetME()->TriggerOffsetTPC() << std::endl;
+    for ( auto& roi : event_roi->ROIArray() ) {
+      if ( roi.Type()==kROIBNB ) {
+	vertex.SetX( roi.X() );
+	vertex.SetY( roi.Y() );
+	vertex.SetZ( roi.Z() );
+	vertex_t       = roi.T(); // G4 time [ns]
+	vertex_tdrift  = roi.X()/::larutil::LArProperties::GetME()->DriftVelocity(); // [us]
+	vertex_tg4elec = ::larutil::TimeService::GetME()->G4ToElecTime( vertex_t ); // 
+	vertex_tick    = fImageTickStart + (vertex_tg4elec-::larutil::TimeService::GetME()->TriggerTime() +vertex_tdrift + 400.333)/0.5; // hacks!!
+	vertex_found   = true;
+	break;
+      }
+    }
+
+    double plane_offsets_ticks[3] = { 0.0, 
+				      0.3/::larutil::LArProperties::GetME()->DriftVelocity()/0.5, 
+				      0.6/::larutil::LArProperties::GetME()->DriftVelocity()/0.5 };
+
+    if ( !vertex_found )
+      return false;
+    LARCV_DEBUG() << "Vertex: (" << vertex.X() << ", " << vertex.Y() << ", " << vertex.Z() << ","
+		 << " t=" << vertex_t*1.0e-3 << " us : "
+		 << " tdrift=" << vertex_tdrift << " us : "
+		 << " tg4elec=" << vertex_tg4elec << " us :  "
+		 << " tg4elec-trig=" << vertex_tg4elec-::larutil::TimeService::GetME()->TriggerTime() << " us :  "
+		 << " tick=" << vertex_tick << ")" << std::endl;
+
+
+    std::vector< larcv::Image2D > image_v;
+    event_original->Move(image_v ); // original moves ownership of its image vectors to us
+ 
+    std::vector< larcv::Image2D > vertex_image_v; // space for new images if we are not working in place
+
+    std::vector<float> _buffer;
+    for ( size_t i=0; i<image_v.size(); ++i ) {
+
+      // get access to the data
+      larcv::Image2D& original_image = image_v[i];
+      int plane = original_image.meta().plane();
+      
+      // get the image size
+      int orig_rows = original_image.meta().rows();
+      int orig_cols = original_image.meta().cols();
+      
+      // get the origin
+      float topleft_x = original_image.meta().min_x();
+
+      // get width
+      float width_per_pixel  = original_image.meta().pixel_width();
+      float height_per_pixel = original_image.meta().pixel_height();
+
+      // get vertex in image
+      // copied from supera
+      double min_wire=0;
+      double max_wire=::larutil::Geometry::GetME()->Nwires(plane)-1;
+      double wire=::larutil::Geometry::GetME()->WireCoordinate(vertex,plane) + 0.5;
+      if(wire<min_wire) wire = min_wire;
+      if(wire>max_wire) wire = max_wire;
+
+      int pixel_vertex_wire = (wire - topleft_x)/width_per_pixel;
+      int pixel_vertex_time = (vertex_tick + plane_offsets_ticks[plane] - original_image.meta().min_y())/height_per_pixel;
+      
+      LARCV_DEBUG() << "origin: (" << topleft_x << "," << original_image.meta().min_y() << ")" << std::endl;
+      LARCV_DEBUG() << "pixel vertex plane=" << plane << " (" << pixel_vertex_wire << ", " << pixel_vertex_time << ") " 
+		    << "max(" << orig_cols << "," << orig_rows << ") " 
+		    << "ds(" << width_per_pixel << "," << height_per_pixel << ")" << std::endl;
+
+      // define the new image
+      larcv::Image2D new_image( original_image.meta() );
+      new_image.paint( 0.0 );
+
+      if ( (pixel_vertex_wire>=0 && pixel_vertex_wire < orig_cols) && (pixel_vertex_time>=0 && pixel_vertex_time<orig_rows) ) {
+	
+	for (int r=pixel_vertex_time-fVertexRadius; r<=pixel_vertex_time+fVertexRadius; r++) {
+	  if ( r<0 ) continue;
+	  if ( r>=orig_rows ) continue;
+	  for (int c=pixel_vertex_wire-fVertexRadius; c<=pixel_vertex_wire+fVertexRadius; c++) {
+	    if ( c<0 ) continue;
+	    if ( c>=orig_cols ) continue;
+	    double dr = r-pixel_vertex_time;
+	    double dc = c-pixel_vertex_wire;
+	    if ( sqrt( dr*dr + dc*dc ) < fVertexRadius )
+	      LARCV_DEBUG() << "Mark pixel: (" << c << "," << orig_rows-r << ")" << std::endl;
+	      new_image.set_pixel( orig_rows-r, c, fMarkValue );
+	  }
+	}
+      }
+      
+      vertex_image_v.emplace_back( std::move(new_image) );
+    }
+
+    // store
+    if ( finplace ) {
+      // give the new images
+      event_original->Emplace( std::move(vertex_image_v) );
+    }
+    else {
+      // return the original images
+      event_original->Emplace( std::move( image_v ) );
+      // we give the new image2d container our relabeled images
+      event_vertex->Emplace( std::move(vertex_image_v) );
+    }
+    
+    return true;
+
+  }
+
+  void VertexImg::finalize()
+  {}
+
+}
+#endif

--- a/app/VertexImg/VertexImg.h
+++ b/app/VertexImg/VertexImg.h
@@ -1,0 +1,78 @@
+/**
+ * \file VertexImg.h
+ *
+ * \ingroup Package_Name
+ * 
+ * \brief Class def header for a class VertexImg
+ *
+ * @author taritree
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __VERTEXIMG_H__
+#define __VERTEXIMG_H__
+
+#include "Processor/ProcessBase.h"
+#include "Processor/ProcessFactory.h"
+
+#include <string>
+
+namespace larcv {
+
+  /**
+     \class ProcessBase
+     User defined class VertexImg ... these comments are used to generate
+     doxygen documentation!
+  */
+  class VertexImg : public ProcessBase {
+
+  public:
+    
+    /// Default constructor
+    VertexImg(const std::string name="VertexImg");
+    
+    /// Default destructor
+    ~VertexImg(){}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+
+  protected:
+    
+    std::string fROIProducerName;
+    std::string fImageProducerName;
+    std::string fOutputProducerName;
+    bool finplace;
+    int fImageTickStart;
+    int fVertexRadius;
+    int fMarkValue;
+  };
+
+  /**
+     \class larcv::VertexImgFactory
+     \brief A concrete factory class for larcv::VertexImg
+  */
+  class VertexImgProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    VertexImgProcessFactory() { ProcessFactory::get().add_factory("VertexImg",this); }
+    /// dtor
+    ~VertexImgProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new VertexImg(instance_name); }
+
+  };
+
+}
+
+#endif
+/** @} */ // end of doxygen group 
+

--- a/app/VertexImg/run.py
+++ b/app/VertexImg/run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import ROOT
+import sys, os
+for l in [x for x in os.listdir(os.environ['LARCV_LIBDIR']) if x.endswith('.so')]:
+   ROOT.gSystem.Load('%s/%s' % (os.environ['LARCV_LIBDIR'],l))
+
+from ROOT import std
+from larcv import larcv
+
+if len(sys.argv) < 2:
+
+   print 'Usage: python',sys.argv[0],'CONFIG_FILE [LARCV_FILE1 LARCV_FILE2 ...]'
+   sys.exit(1)
+
+proc = larcv.ProcessDriver('ProcessDriver')
+
+proc.configure(sys.argv[1])
+
+if len(sys.argv) > 1:
+   
+   flist=ROOT.std.vector('std::string')()
+   for x in xrange(len(sys.argv)-2):
+      flist.push_back(sys.argv[x+2])
+
+   proc.override_input_file(flist)
+
+proc.initialize()
+
+proc.batch_process(0,20)
+
+proc.finalize()

--- a/app/VertexImg/verteximg.cfg
+++ b/app/VertexImg/verteximg.cfg
@@ -1,0 +1,32 @@
+
+ProcessDriver: {
+
+  Verbosity:    0
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["VertexImg"]
+  ProcessName:  ["VertexImg"]
+
+  IOManager: {
+    Verbosity:   2
+    Name:        "IOManager"
+    IOMode:      2
+    OutFileName: "out_test_verteximg.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: [               0,                 0,    1]
+    StoreOnlyName: ["tpc_hires_crop","tpc_hires_vertex","tpc"]
+  }
+
+  ProcessList: {
+    VertexImg: {
+      Verbosity: 2
+      ROIProducerName: "tpc"
+      ImageProducerName: "tpc_hires_crop"
+      OutputProducerName: "tpc_hires_vertex"
+      ImageTickStart: 2400
+      VertexRadius: 2
+    }
+  }
+}
+


### PR DESCRIPTION
Example of what is does:

For a given image:
![tpc_image](https://cloud.githubusercontent.com/assets/7130028/18324766/2866c10a-750c-11e6-9da2-86a821d164e5.png)

If the vertex is contained within the region, a new image is made that marks the location of the true interaction vertex:
![marked_vertex](https://cloud.githubusercontent.com/assets/7130028/18324771/2cd22de2-750c-11e6-9cf1-91233271bb93.png)
