### PR TITLE
Added ImageMod module ROIMask

### DIFF
--- a/app/ImageMod/LinkDef.h
+++ b/app/ImageMod/LinkDef.h
@@ -29,7 +29,9 @@
 #pragma link C++ class larcv::SegmentMask+;
 #pragma link C++ class larcv::SegmentMaker+;
 #pragma link C++ class larcv::CropROI+;
+#pragma link C++ class larcv::ROIMask+;
 //ADD_NEW_CLASS ... do not change this line
 #endif
+
 
 

--- a/app/ImageMod/README.md
+++ b/app/ImageMod/README.md
@@ -8,8 +8,10 @@ Short description of each module can be found in the table below, followed by de
 
 | Module Name | Short Description |
 |-------------|:-----------------:|
-| WireMask | Mask certain column pixels in an image |
+| EmbedImage  | Embed image into a larger, blank, image |
+| ROIMask     | Mask out parts of image using ROI |
 | SegmentRelabel | Relabel segmentation map value |
+| WireMask | Mask certain column pixels in an image |
 
 
 ## Description of each module
@@ -19,6 +21,7 @@ Please provide a detailed description of each module here. (Sorted in Alphabetic
 List of modules:
 
 * EmbedImage
+* ROIMask
 * SegmentRelabel
 * WireMask
 
@@ -44,6 +47,18 @@ Parameters
 | OutputRows | size of output rows (must be bigger than original) |
 | OutputCols | size of output cols (must be bigger than original) |
 
+### ROIMask
+
+This module allows one to mask out parts of an image using an ROI.  One can either blank out the region inside or outside the ROI.
+
+Parameters
+
+| Parameters | Description  |
+|------------|:------------:|
+|InputImageProducer| (string) Input Image2D producer name. |
+|OutputImageProducer| (string) Output Image2d producer name. If the same as the input producer, then modification made in-place. |
+|InputROIProducer| (string) ROI producer name from which we get the masking producer |
+|MaskOutsideROI  | (bool) If true, blank out region outside the ROI. If false, blank out region inside the ROI. |
 
 ### SegmentRelabel
 

--- a/app/ImageMod/README.md
+++ b/app/ImageMod/README.md
@@ -59,6 +59,7 @@ Parameters
 |OutputImageProducer| (string) Output Image2d producer name. If the same as the input producer, then modification made in-place. |
 |InputROIProducer| (string) ROI producer name from which we get the masking producer |
 |MaskOutsideROI  | (bool) If true, blank out region outside the ROI. If false, blank out region inside the ROI. |
+|CutOutOfBounds  | (bool, optional, default=true) If true, if ROI extends outside of image in anyway, event is skipped. Otherwise blank image inserted. |
 
 ### SegmentRelabel
 

--- a/app/ImageMod/README.md
+++ b/app/ImageMod/README.md
@@ -58,8 +58,11 @@ Parameters
 |InputImageProducer| (string) Input Image2D producer name. |
 |OutputImageProducer| (string) Output Image2d producer name. If the same as the input producer, then modification made in-place. |
 |InputROIProducer| (string) ROI producer name from which we get the masking producer |
+|OutputROIProducer| (string) ROI producer name into which we store the ROI |
 |MaskOutsideROI  | (bool) If true, blank out region outside the ROI. If false, blank out region inside the ROI. |
 |CutOutOfBounds  | (bool, optional, default=true) If true, if ROI extends outside of image in anyway, event is skipped. Otherwise blank image inserted. |
+|ROIid | (int, optional, default=0) Index of ROI array to use |
+|ROILabel | (int, optional, default=2,kROIBNB) Label given to output ROI |
 
 ### SegmentRelabel
 

--- a/app/ImageMod/ROIMask.cxx
+++ b/app/ImageMod/ROIMask.cxx
@@ -1,0 +1,36 @@
+#ifndef __ROIMASK_CXX__
+#define __ROIMASK_CXX__
+
+#include "ROIMask.h"
+
+namespace larcv {
+
+  static ROIMaskProcessFactory __global_ROIMaskProcessFactory__;
+
+  ROIMask::ROIMask(const std::string name)
+    : ProcessBase(name)
+  {}
+    
+  void ROIMask::configure(const PSet& cfg)
+  {
+    fInputImageProducer  = cfg.get<std::string>( "InputImageProducer" );
+    fOutputImageProducer = cfg.get<std::string>( "OutputImageProducer" );
+    fInputROIProducer    = cfg.get<std::string>( "InputROIProducer" );
+    fMaskOutsideROI      = cfg.get<bool>( "MaskOutsideROI" );
+
+    if (fInputImageProducer==fOutputImageProducer) inplace = true;
+    else inplace = false;
+      
+  }
+
+  void ROIMask::initialize()
+  {}
+
+  bool ROIMask::process(IOManager& mgr)
+  {}
+
+  void ROIMask::finalize()
+  {}
+
+}
+#endif

--- a/app/ImageMod/ROIMask.cxx
+++ b/app/ImageMod/ROIMask.cxx
@@ -2,6 +2,8 @@
 #define __ROIMASK_CXX__
 
 #include "ROIMask.h"
+#include "DataFormat/EventImage2D.h"
+#include "DataFormat/EventROI.h"
 
 namespace larcv {
 
@@ -18,8 +20,8 @@ namespace larcv {
     fInputROIProducer    = cfg.get<std::string>( "InputROIProducer" );
     fMaskOutsideROI      = cfg.get<bool>( "MaskOutsideROI" );
 
-    if (fInputImageProducer==fOutputImageProducer) inplace = true;
-    else inplace = false;
+    if (fInputImageProducer==fOutputImageProducer) finplace = true;
+    else finplace = false;
       
   }
 
@@ -27,7 +29,101 @@ namespace larcv {
   {}
 
   bool ROIMask::process(IOManager& mgr)
-  {}
+  {
+
+    // Get images (and setup output)
+    EventImage2D* event_original = (EventImage2D*)mgr.get_data(kProductImage2D, fInputImageProducer);
+    EventImage2D* event_masked   = NULL;
+    if (!finplace)
+      event_masked  = (EventImage2D*)mgr.get_data(kProductImage2D, fOutputImageProducer);
+    else
+      event_masked  = event_original;
+
+    if ( !event_original ) {
+      LARCV_ERROR() << "Could not open input images." << std::endl;
+      return false;
+    }
+    if ( !event_masked )  {
+      LARCV_ERROR() << "Could not open output image holder." << std::endl;
+      return false;      
+    }
+
+    // Get ROI
+    EventROI* event_roi = (EventROI*)mgr.get_data(kProductROI, fInputROIProducer);
+    auto rois = event_roi->ROIArray();
+    int roi_id = 0;
+
+    // original moves ownership of its image vectors to us
+    std::vector< larcv::Image2D> image_v;
+    event_original->Move(image_v ); 
+ 
+    // container for new images if we are not working in place
+    std::vector< larcv::Image2D > masked_image_v; 
+
+    std::vector<float> _buffer;
+    for ( size_t i=0; i<image_v.size(); ++i ) {
+
+      // get access to the data
+      larcv::Image2D& original_image = image_v[i];
+
+      auto meta = original_image.meta();
+      auto roi = rois.at(roi_id);
+      auto bb  = roi.BB( meta.plane() );
+
+      // make roi meta with same scale as input image
+      double origin_x = bb.min_x();
+      double origin_y = bb.max_y();
+      double width    = bb.width();
+      double height   = bb.height();
+
+      // get row and col size based on scale of original image
+      int cols = (int)width/meta.pixel_width();
+      int rows = (int)height/meta.pixel_height();
+
+      ImageMeta maskedmeta( width, height, rows, cols, origin_x, origin_y, meta.plane() );
+
+      if ( fMaskOutsideROI ) {
+	// we want everything but the ROI to be zero
+
+	// we crop out the region we're interested in
+	larcv::Image2D cropped_image = original_image.crop( maskedmeta );
+      
+	// define the new image, and blank it out
+	larcv::Image2D new_image( meta );
+	new_image.paint( 0.0 );
+	// overlay cropped image
+	new_image.overlay( cropped_image );
+	masked_image_v.emplace_back( std::move(new_image) );
+      }
+      else {
+	// we want to zero the region inside the ROI
+
+	// make blank with size of ROi
+	larcv::Image2D roi_blank( maskedmeta );
+	roi_blank.paint(0.0);
+
+	// make copy of original
+	larcv::Image2D new_image( meta, original_image.as_vector() );
+	new_image.overlay( roi_blank );
+	masked_image_v.emplace_back( std::move(new_image) );
+      }
+      
+    }
+
+    // store
+    if ( finplace ) {
+      // give the new images
+      event_original->Emplace( std::move(masked_image_v) );
+    }
+    else {
+      // return the original images
+      event_original->Emplace( std::move( image_v ) );
+      // we give the new image2d container our relabeled images
+      event_masked->Emplace( std::move(masked_image_v) );
+    }
+
+
+  }
 
   void ROIMask::finalize()
   {}

--- a/app/ImageMod/ROIMask.cxx
+++ b/app/ImageMod/ROIMask.cxx
@@ -75,6 +75,11 @@ namespace larcv {
       larcv::Image2D& original_image = image_v[i];
 
       auto meta = original_image.meta();
+      if ( rois.size()<=0 ) {
+	outofbounds = true;
+	break;
+      }
+
       auto roi = rois.at(fROIid); // fixme: smarter choice of ROI?
       auto bb  = roi.BB( meta.plane() );
 
@@ -87,6 +92,16 @@ namespace larcv {
       // get row and col size based on scale of original image
       int cols = (int)width/meta.pixel_width();
       int rows = (int)height/meta.pixel_height();
+      
+      if ( rows==0 || height<meta.pixel_height() ) {
+	// 0 thick roi...
+	height=meta.pixel_height();
+	rows = 1;
+      }
+      if ( cols==0 || width<meta.pixel_width() ) {
+	width = meta.pixel_width();
+	cols = 1;
+      }
 
       ImageMeta maskedmeta( width, height, rows, cols, origin_x, origin_y, meta.plane() );
 

--- a/app/ImageMod/ROIMask.h
+++ b/app/ImageMod/ROIMask.h
@@ -18,6 +18,9 @@
 
 #include "Processor/ProcessBase.h"
 #include "Processor/ProcessFactory.h"
+
+#include <string>
+
 namespace larcv {
 
   /**
@@ -48,7 +51,7 @@ namespace larcv {
     std::string fOutputImageProducer;
     std::string fInputROIProducer;
     bool fMaskOutsideROI;
-    bool inplace;
+    bool finplace;
 
   };
 

--- a/app/ImageMod/ROIMask.h
+++ b/app/ImageMod/ROIMask.h
@@ -1,0 +1,73 @@
+/**
+ * \file ROIMask.h
+ *
+ * \ingroup ImageMod
+ * 
+ * \brief Class def header for a class ROIMask
+ *
+ * This class takes ROIs and masks out either inside or outside the region.
+ *
+ * @author tmw
+ */
+
+/** \addtogroup Package_Name
+
+    @{*/
+#ifndef __ROIMASK_H__
+#define __ROIMASK_H__
+
+#include "Processor/ProcessBase.h"
+#include "Processor/ProcessFactory.h"
+namespace larcv {
+
+  /**
+     \class ProcessBase
+     User defined class ROIMask ... these comments are used to generate
+     doxygen documentation!
+  */
+  class ROIMask : public ProcessBase {
+
+  public:
+    
+    /// Default constructor
+    ROIMask(const std::string name="ROIMask");
+    
+    /// Default destructor
+    ~ROIMask(){}
+
+    void configure(const PSet&);
+
+    void initialize();
+
+    bool process(IOManager& mgr);
+
+    void finalize();
+
+  protected:
+    std::string fInputImageProducer;
+    std::string fOutputImageProducer;
+    std::string fInputROIProducer;
+    bool fMaskOutsideROI;
+    bool inplace;
+
+  };
+
+  /**
+     \class larcv::ROIMaskFactory
+     \brief A concrete factory class for larcv::ROIMask
+  */
+  class ROIMaskProcessFactory : public ProcessFactoryBase {
+  public:
+    /// ctor
+    ROIMaskProcessFactory() { ProcessFactory::get().add_factory("ROIMask",this); }
+    /// dtor
+    ~ROIMaskProcessFactory() {}
+    /// creation method
+    ProcessBase* create(const std::string instance_name) { return new ROIMask(instance_name); }
+  };
+
+}
+
+#endif
+/** @} */ // end of doxygen group 
+

--- a/app/ImageMod/ROIMask.h
+++ b/app/ImageMod/ROIMask.h
@@ -52,6 +52,7 @@ namespace larcv {
     std::string fInputROIProducer;
     bool fMaskOutsideROI;
     bool finplace;
+    bool fCutOutOfBounds;
 
   };
 

--- a/app/ImageMod/ROIMask.h
+++ b/app/ImageMod/ROIMask.h
@@ -50,9 +50,12 @@ namespace larcv {
     std::string fInputImageProducer;
     std::string fOutputImageProducer;
     std::string fInputROIProducer;
+    std::string fOutputROIProducer;
     bool fMaskOutsideROI;
     bool finplace;
     bool fCutOutOfBounds;
+    int fROIid;
+    larcv::ROIType_t fROILabel;
 
   };
 

--- a/app/ImageMod/roimask.cfg
+++ b/app/ImageMod/roimask.cfg
@@ -14,18 +14,20 @@ ProcessDriver: {
     OutFileName: "out_test.root"
     InputFiles:  []
     InputDirs:   []
-    StoreOnlyType: [           0]
-    StoreOnlyName: ["tpc_masked"]
+    StoreOnlyType: [           0,           1]
+    StoreOnlyName: ["tpc_masked","tpc_masked"]
   }
 
   ProcessList: {
     ROIMask: {
-      Verbosity: 0
+      Verbosity: 2
       InputImageProducer: "tpc"
       OutputImageProducer:"tpc_masked"
       InputROIProducer: "protonBDT"
+      OutputROIProducer: "tpc_masked"
       MaskOutsideROI: true
       CutOutOfBounds: false
+      ROILabel: 9
     }
   }
 }

--- a/app/ImageMod/roimask.cfg
+++ b/app/ImageMod/roimask.cfg
@@ -1,0 +1,32 @@
+
+ProcessDriver: {
+
+  Verbosity:    0
+  EnableFilter: true
+  RandomAccess: false
+  ProcessType:  ["ROIMask"]
+  ProcessName:  ["ROIMask"]
+
+  IOManager: {
+    Verbosity:   2
+    Name:        "IOManager"
+    IOMode:      2
+    OutFileName: "out_test.root"
+    InputFiles:  []
+    InputDirs:   []
+    StoreOnlyType: [           0]
+    StoreOnlyName: ["tpc_masked"]
+  }
+
+  ProcessList: {
+    ROIMask: {
+      Verbosity: 0
+      InputImageProducer: "tpc"
+      OutputImageProducer:"tpc_masked"
+      InputROIProducer: "protonBDT"
+      MaskOutsideROI: true
+      CutOutOfBounds: false
+    }
+  }
+}
+

--- a/app/ImageMod/roimask.cfg
+++ b/app/ImageMod/roimask.cfg
@@ -11,11 +11,11 @@ ProcessDriver: {
     Verbosity:   2
     Name:        "IOManager"
     IOMode:      2
-    OutFileName: "out_test.root"
+    OutFileName: "output_roimask.root"
     InputFiles:  []
     InputDirs:   []
-    StoreOnlyType: [           0,           1]
-    StoreOnlyName: ["tpc_masked","tpc_masked"]
+    StoreOnlyType: [           0,           1,          1]
+    StoreOnlyName: ["tpc_masked","tpc_masked","protonBDT"]
   }
 
   ProcessList: {


### PR DESCRIPTION
Allows one to use an ROI to mask an image. One may zero out within the ROI or outside the ROI. Initial use case is to create a single particle proton data sample.

Unmasked, original image:
![unmasked](https://cloud.githubusercontent.com/assets/7130028/18657533/b883236a-7ec0-11e6-824a-a5d791faaa28.png)

Masked image:
![masked](https://cloud.githubusercontent.com/assets/7130028/18657537/c075242e-7ec0-11e6-9255-3e4fb9e97d71.png)
