### PR TITLE
Move explicit template instantiation out of header to .cxx file.

### DIFF
--- a/app/APICaffe/CircularBufferBase.cxx
+++ b/app/APICaffe/CircularBufferBase.cxx
@@ -156,6 +156,6 @@ namespace larcv {
   }
 }
 
-#include "CircularBufferBase.imp.h"
+template class larcv::CircularBufferBase<std::vector<double> >;
 
 #endif

--- a/app/APICaffe/CircularBufferBase.imp.h
+++ b/app/APICaffe/CircularBufferBase.imp.h
@@ -1,8 +1,0 @@
-#ifndef CIRCULARBUFFERBASE_IMP_H
-#define CIRCULARBUFFERBASE_IMP_H
-
-#include "CircularBufferBase.h"
-
-template class larcv::CircularBufferBase<std::vector<double> >;
-
-#endif


### PR DESCRIPTION
Fixes macos duplicate symbol.  Move tag v06_26_01_01.
